### PR TITLE
fix: Fixed failure on exporting ICS when user not logged in to Chrome

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -163,6 +163,8 @@ function getFormsValue(selectedOptionValue) {
 async function handleFlow(selectedColorValue, selectedCalendar, selectedReminderTime, selectedSemesterValue, selectedEventFormat, selectedOptionValue) {
     try {
         let token = null;
+        
+        // Only try to get token if the selected options require Google account access
         if (selectedOptionValue == 1 || selectedOptionValue == 3) {
             // Get Oauth token
             token = await getAuthToken();

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -162,8 +162,11 @@ function getFormsValue(selectedOptionValue) {
 // This function handles token and window flow
 async function handleFlow(selectedColorValue, selectedCalendar, selectedReminderTime, selectedSemesterValue, selectedEventFormat, selectedOptionValue) {
     try {
-        // Get Oauth token
-        const token = await getAuthToken();
+        let token = null;
+        if (selectedOptionValue == 1 || selectedOptionValue == 3) {
+            // Get Oauth token
+            token = await getAuthToken();
+        }
 
         // Get the current active tab
         const currTab = await getCurrTab();


### PR DESCRIPTION
---
Name: Fixed failure on exporting ICS when user not logged in to Chrome
About: Without a Google account, the extension would fail on downloading ICS file, even though processing ICS files does not require a Google Account. This pull request should fix that by adding a check on `handleFlow()`.
Title: ''
Labels: ''
Assignees: ''

---

### Description

Without a Google account, the extension would fail on downloading ICS file, even though processing ICS files does not require a Google Account. This pull request should fix that by adding a check on `handleFlow()`. Fixes #26.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please specify): ___________

### Related Issue(s)
- Addresses #26 

### How to Test

1. Install this extension in ungoogled-chromium (or possibly just logout from a Chrome instance)
2. Choose to download ICS file
3. No failure should occur

### Checklist

Please make sure to complete the following before submitting the pull request:

- [x] I have tested the code locally and confirmed that the changes work as expected.
- [ ] I have written unit tests (if applicable) for the changes I made.
- [ ] I have updated the documentation (if necessary).
- [x] I have followed the coding standards and conventions used in this repository.
- [ ] I have updated the `CHANGELOG.md` (if applicable).
- [ ] I have added any necessary environment variables or API keys (please provide instructions if relevant).

### Additional Context

amogus